### PR TITLE
Fix Income Record Type Error on Build

### DIFF
--- a/src/components/AddIncomeRecord.vue
+++ b/src/components/AddIncomeRecord.vue
@@ -139,7 +139,7 @@ const paymentType = ref<string>("full");
 const recordType = RecordType.INCOME;
 
 const recordIncomeSourceId = ref<string | null>(null);
-const recordAmount = ref<number>();
+const recordAmount = ref<number>(0);
 const recordCurrencyId = ref<string | null>(null);
 const recordCurrencySign = ref<string | null>(null);
 const recordPartyId = ref<string | null>(null);


### PR DESCRIPTION
Initialize the `recordAmount` variable to prevent errors during the build process related to the income record type.